### PR TITLE
Improved event infos arrangement

### DIFF
--- a/app/assets/javascripts/calendar.js
+++ b/app/assets/javascripts/calendar.js
@@ -1,9 +1,23 @@
 $('document').ready(function() {
   $('#calendar').fullCalendar({
     events: '/events.json', 
-    eventRender: function(event, element) { 
+    eventRender: function(event, element) {
+      console.log(element)
       element.find('.fc-title').append("<br/>" + event.nome + " " + event.pilar);
       element.find('.fc-title').append("<br/>" + event.descricao);
+      switch (event.pilar) {
+        case 'Redes':
+          element.addClass("redes");
+          break
+        case 'Mercado':
+          element.addClass("mercado");
+          break
+        case 'Propósito':
+          element.addClass("proposito");
+          break    
+        default:
+          break
+      }
     },
     theme: true,
     lang: 'pt-br',

--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -3,6 +3,11 @@
   width: 60%;
 }
 
+.actions {
+  margin: 0 auto;
+  width: 60%;
+}
+
 /* Navigation Styles */
 
 .header {

--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -51,6 +51,18 @@
   padding: 20px 5%;
 }
 
+.redes {
+    background-color: #800000 !important;
+}
+
+.mercado {
+    background-color: #006400 !important;
+}
+
+.proposito {
+    background-color: #000000 !important;
+}
+
 /* Footer Styles */
 
 .footer {

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,3 +1,8 @@
 class Event < ActiveRecord::Base
   validates :nome, :pilar, :descricao, :local, presence: true
+
+  def self.pilares
+     [['Liderança','Liderança'], ['Redes', 'Redes'], ['Mercado', 'Mercado'], ['Propósito', 'Propósito']]
+  end
+
 end

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -10,7 +10,20 @@
 <% @events.each do |event| %>
 
 <div class="event jumbotron">
-  <h3><strong><%= event.nome %> </strong><span class="label label-primary"> <%= event.pilar %> </span></h3>
+  <h3><strong><%= event.nome + "|" %> </strong>
+    
+    <% case event.pilar %>
+    <% when 'Redes' %>
+      <span class="label label-primary redes"> 
+    <% when 'Mercado' %>
+       <span class="label label-primary mercado"> 
+    <% when 'Propósito' %>
+       <span class="label label-primary proposito"> 
+    <% else %>
+      <span class="label label-primary"> 
+    <% end %>
+
+      <%= event.pilar %> </span></h3>
   <hr>
   <div class="row info">
     <div class="col-xs-6">

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -10,8 +10,8 @@
 <% @events.each do |event| %>
 
 <div class="event jumbotron">
-  <h3><strong><%= event.nome + "|" %> </strong>
-    
+  <h3><strong><%= event.nome + " | " %> </strong>
+
     <% case event.pilar %>
     <% when 'Redes' %>
       <span class="label label-primary redes"> 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -10,20 +10,23 @@
 <% @events.each do |event| %>
 
 <div class="event jumbotron">
-  <h3><strong>Evento <%= event.id %> - <%= event.nome %> </strong><span class="label label-primary"> <%= event.pilar %> </span></h3>
+  <h3><strong><%= event.nome %> </strong><span class="label label-primary"> <%= event.pilar %> </span></h3>
   <hr>
   <div class="row info">
-    <div class="col-xs-3">
-      <p><span class="label label-default">Ciclo</span> <%= event.ciclo %> </p>
-      <p><span class="label label-warning">Local</span> <%= event.local %> </p>
-    </div>
-    <div class="col-xs-3">
-      <p><strong>Início </strong><%= event.hora_inicio.to_formatted_s(:short) %> </p>
-      <p><strong>Final </strong><%= event.hora_fim.to_formatted_s(:short) %> </p>
-           
+    <div class="col-xs-6">
+      <p><strong>Início: </strong><%= event.hora_inicio.to_formatted_s(:short) %> </p>
     </div>
     <div class="col-xs-6">
-      <p><strong>Descrição </strong><%= event.descricao %> </p>
+      <p><strong>Final: </strong><%= event.hora_fim.to_formatted_s(:short) %> </p>
+    </div>
+    <div class="col-xs-12">
+      <p><strong>Descrição: </strong><%= event.descricao %> </p>
+    </div>
+    <div class="col-xs-6">
+      <p><span class="label label-warning">Local</span> <%= event.local %> </p>
+    </div>
+    <div class="col-xs-6">
+      <p><span class="label label-default">Ciclo</span> <%= event.ciclo %> </p>
     </div>
   </div>
   <div class="row">

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -23,7 +23,7 @@
  
   <p>
     <%= f.label :pilar %><br>
-    <%= f.text_field :pilar, class: "form-control" %>
+    <%= f.select :pilar, Event.pilares %>
   </p>
   
     <p>
@@ -38,12 +38,12 @@
   
   <p>
     <%= f.label :hora_inicio %><br>
-    <%= f.text_field :hora_inicio, class: "form-control" %>
+    <%= f.datetime_field :hora_inicio, class: "form-control" %>
   </p>
   
   <p>
     <%= f.label :hora_fim %><br>
-    <%= f.text_field :hora_fim, class: "form-control" %>
+    <%= f.datetime_field :hora_fim, class: "form-control" %>
   </p>
   
   <p>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -2,23 +2,36 @@
 
 <h3>Resumo do Evento</h3>
 <div class="event jumbotron">
-  <h3><strong><%= @event.nome %> </strong><span class="label label-primary"> <%= @event.pilar %> </span></h3>
+  <h3><strong><%= @event.nome  %> </strong>
+
+    <% case @event.pilar %>
+    <% when 'Redes' %>
+      <span class="label label-primary redes"> 
+    <% when 'Mercado' %>
+       <span class="label label-primary mercado"> 
+    <% when 'Propósito' %>
+       <span class="label label-primary proposito"> 
+    <% else %>
+      <span class="label label-primary"> 
+    <% end %>
+    <%= @event.pilar %> </span></h3>
+
   <hr>
   <div class="row info">
     <div class="col-xs-6">
-      <p><strong>Início: </strong><%= event.hora_inicio.to_formatted_s(:short) %> </p>
+      <p><strong>Início: </strong><%= @event.hora_inicio.to_formatted_s(:short) %></p>
     </div>
     <div class="col-xs-6">
-      <p><strong>Final: </strong><%= event.hora_fim.to_formatted_s(:short) %> </p>
+      <p><strong>Final: </strong><%= @event.hora_fim.to_formatted_s(:short) %> </p>
     </div>
     <div class="col-xs-12">
-      <p><strong>Descrição: </strong><%= event.descricao %> </p>
+      <p><strong>Descrição: </strong><%= @event.descricao %> </p>
     </div>
     <div class="col-xs-6">
-      <p><span class="label label-warning">Local</span> <%= event.local %> </p>
+      <p><span class="label label-warning">Local</span> <%= @event.local %> </p>
     </div>
     <div class="col-xs-6">
-      <p><span class="label label-default">Ciclo</span> <%= event.ciclo %> </p>
+      <p><span class="label label-default">Ciclo</span> <%= @event.ciclo %> </p>
     </div>
   </div>
   <div class="row">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -2,7 +2,7 @@
 
 <h3>Resumo do Evento</h3>
 <div class="event jumbotron">
-  <h3><strong>Evento <%= @event.id %> - <%= @event.nome %> </strong><span class="label label-primary"> <%= @event.pilar %> </span></h3>
+  <h3><strong><%= @event.nome %> </strong><span class="label label-primary"> <%= @event.pilar %> </span></h3>
   <hr>
   <div class="row info">
     <div class="col-xs-3">

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -5,17 +5,20 @@
   <h3><strong><%= @event.nome %> </strong><span class="label label-primary"> <%= @event.pilar %> </span></h3>
   <hr>
   <div class="row info">
-    <div class="col-xs-3">
-      <p><span class="label label-default">Ciclo</span> <%= @event.ciclo %> </p>
-      <p><span class="label label-warning">Local</span> <%= @event.local %> </p>
-    </div>
-    <div class="col-xs-3">
-      <p><strong>Início </strong><%= @event.hora_inicio.to_formatted_s(:short) %> </p>
-      <p><strong>Final </strong><%= @event.hora_fim.to_formatted_s(:short) %> </p>
-           
+    <div class="col-xs-6">
+      <p><strong>Início: </strong><%= event.hora_inicio.to_formatted_s(:short) %> </p>
     </div>
     <div class="col-xs-6">
-      <p><strong>Descrição </strong><%= @event.descricao %> </p>
+      <p><strong>Final: </strong><%= event.hora_fim.to_formatted_s(:short) %> </p>
+    </div>
+    <div class="col-xs-12">
+      <p><strong>Descrição: </strong><%= event.descricao %> </p>
+    </div>
+    <div class="col-xs-6">
+      <p><span class="label label-warning">Local</span> <%= event.local %> </p>
+    </div>
+    <div class="col-xs-6">
+      <p><span class="label label-default">Ciclo</span> <%= event.ciclo %> </p>
     </div>
   </div>
   <div class="row">

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -1,5 +1,5 @@
 <div class="header navbar">
   <div class="logo">
-    <%= image_tag("NucleoSP.png", class: "img-responsive")%>
+    <%= link_to (image_tag("NucleoSP.png", class: "img-responsive")), root_url%>
   </div>
 </div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,44 +1,53 @@
 
-  <p class="title">Calendário de Atividades</p>
-  <div id="calendar"></div>
+<p class="title">Calendário de Atividades</p>
 
-      <div class="container atividades">
-        <p class="title-2">Atividades Próximas</p>
-          
-        <div>
-          <%= link_to 'Lista Completa', events_path, class: "btn btn-default" %>
-          <%= link_to 'Novo Evento', new_event_path, class: "btn btn-default" %>
-        </div>
-        
-        <% @events.each do |event| %>
-        
-          <div class="event jumbotron">
-            <h3><strong>Evento <%= event.id %> - <%= event.nome %> </strong><span class="label label-primary"> <%= event.pilar %> </span></h3>
-            <hr>
-            <div class="row info">
-              <div class="col-xs-3">
-                <p><span class="label label-default">Ciclo</span> <%= event.ciclo %> </p>
-                <p><span class="label label-warning">Local</span> <%= event.local %> </p>
-              </div>
-              <div class="col-xs-3">
-                <p><strong>Início </strong><%= event.hora_inicio.to_formatted_s(:short) %> </p>
-                <p><strong>Final </strong><%= event.hora_fim.to_formatted_s(:short) %> </p>
-                     
-              </div>
-              <div class="col-xs-6">
-                <p><strong>Descrição </strong><%= event.descricao %> </p>
-              </div>
-            </div>
-            <div class="row">
-              <div class="col-xs-12">
-                <p><%= link_to 'Editar', edit_event_path(event), class: "btn btn-default" %> <%= link_to 'Deletar', event_path(event), method: :delete, data: {confirm: 'Deseja Excluir?'}, class: "btn btn-default" %></p>
-              </div>
-            </div>  
-          </div>
-        
-        <% end %>
-        
-        <%= link_to 'Lista Completa', events_path, class: "btn btn-default" %>
-        <%= link_to 'Novo Evento', new_event_path, class: "btn btn-default" %>
+<div class="actions">
+  <%= link_to 'Lista Completa', events_path, class: "btn btn-default" %>
+  <%= link_to 'Novo Evento', new_event_path, class: "btn btn-default" %>
+</div>
+<br>
+<div id="calendar"></div>
+
+<div class="container atividades">
+  <p class="title-2">Próximas Atividades</p>
+    
+  <div>
+    <%= link_to 'Lista Completa', events_path, class: "btn btn-default" %>
+    <%= link_to 'Novo Evento', new_event_path, class: "btn btn-default" %>
+  </div>
   
+  <% @events.each do |event| %>
+  
+    <div class="event jumbotron">
+      <h3><strong><%= event.nome %> </strong><span class="label label-primary"> <%= event.pilar %> </span></h3>
+      <hr>
+      <div class="row info">
+        <div class="col-xs-6">
+          <p><strong>Início: </strong><%= event.hora_inicio.to_formatted_s(:short) %> </p>
+        </div>
+        <div class="col-xs-6">
+          <p><strong>Final: </strong><%= event.hora_fim.to_formatted_s(:short) %> </p>
+        </div>
+        <div class="col-xs-12">
+          <p><strong>Descrição: </strong><%= event.descricao %> </p>
+        </div>
+        <div class="col-xs-6">
+          <p><span class="label label-warning">Local</span> <%= event.local %> </p>
+        </div>
+        <div class="col-xs-6">
+          <p><span class="label label-default">Ciclo</span> <%= event.ciclo %> </p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-xs-12">
+          <p><%= link_to 'Editar', edit_event_path(event), class: "btn btn-default" %> <%= link_to 'Deletar', event_path(event), method: :delete, data: {confirm: 'Deseja excluir ' + event.nome + ' ?'}, class: "btn btn-default" %></p>
+        </div>
+      </div>  
     </div>
+  
+  <% end %>
+  
+  <%= link_to 'Lista Completa', events_path, class: "btn btn-default" %>
+  <%= link_to 'Novo Evento', new_event_path, class: "btn btn-default" %>
+
+</div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -19,7 +19,20 @@
   <% @events.each do |event| %>
   
     <div class="event jumbotron">
-      <h3><strong><%= event.nome %> </strong><span class="label label-primary"> <%= event.pilar %> </span></h3>
+      <h3><strong><%= event.nome + " | "%> </strong>
+
+        <% case event.pilar %>
+        <% when 'Redes' %>
+          <span class="label label-primary redes"> 
+        <% when 'Mercado' %>
+           <span class="label label-primary mercado"> 
+        <% when 'Propósito' %>
+           <span class="label label-primary proposito"> 
+        <% else %>
+          <span class="label label-primary"> 
+        <% end %>
+
+          <%= event.pilar %> </span></h3>
       <hr>
       <div class="row info">
         <div class="col-xs-6">


### PR DESCRIPTION
Arrumei a apresentação das informações, coloquei o link para a url principal no logo e também os botões de criação de evento mais próximos do calendário.
![screen shot 2015-12-06 at 5 41 20 pm](https://cloud.githubusercontent.com/assets/3289179/11615223/5dd7825a-9c42-11e5-8bca-1c1ccb2f7d9d.jpg)